### PR TITLE
Change variable name "name" for key

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,17 @@ Now that it’s looking for `write` let’s make that function somewhere in your
 
 ```
 func (t *SimpleChaincode) write(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
-	var name, value string
+	var key, value string
 	var err error
 	fmt.Println("running write()")
 
 	if len(args) != 2 {
-		return nil, errors.New("Incorrect number of arguments. Expecting 2. name of the variable and value to set")
+		return nil, errors.New("Incorrect number of arguments. Expecting 2. name of the key and value to set")
 	}
 
-	name = args[0]                            //rename for fun
+	key = args[0]                            //rename for fun
 	value = args[1]
-	err = stub.PutState(name, []byte(value))  //write the variable into the chaincode state
+	err = stub.PutState(key, []byte(value))  //write the variable into the chaincode state
 	if err != nil {
 		return nil, err
 	}
@@ -166,17 +166,17 @@ Now that it’s looking for `read`, make that function somewhere in your `chainc
 
 ```
 func (t *SimpleChaincode) read(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
-	var name, jsonResp string
+	var key, jsonResp string
 	var err error
 
 	if len(args) != 1 {
-		return nil, errors.New("Incorrect number of arguments. Expecting name of the var to query")
+		return nil, errors.New("Incorrect number of arguments. Expecting name of the key to query")
 	}
 
-	name = args[0]
-	valAsbytes, err := stub.GetState(name)
+	key = args[0]
+	valAsbytes, err := stub.GetState(key)
 	if err != nil {
-		jsonResp = "{\"Error\":\"Failed to get state for " + name + "\"}"
+		jsonResp = "{\"Error\":\"Failed to get state for " + key + "\"}"
 		return nil, errors.New(jsonResp)
 	}
 

--- a/finished/chaincode_finished.go
+++ b/finished/chaincode_finished.go
@@ -68,7 +68,7 @@ func (t *SimpleChaincode) Query(stub *shim.ChaincodeStub, function string, args 
 	fmt.Println("query is running " + function)
 
 	// Handle different functions
-	if function == "read" {                            //read a variable
+	if function == "read" { //read a variable
 		return t.read(stub, args)
 	}
 	fmt.Println("query did not find func: " + function)
@@ -78,17 +78,17 @@ func (t *SimpleChaincode) Query(stub *shim.ChaincodeStub, function string, args 
 
 // write - invoke function to write key/value pair
 func (t *SimpleChaincode) write(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
-	var name, value string
+	var key, value string
 	var err error
 	fmt.Println("running write()")
 
 	if len(args) != 2 {
-		return nil, errors.New("Incorrect number of arguments. Expecting 2. name of the variable and value to set")
+		return nil, errors.New("Incorrect number of arguments. Expecting 2. name of the key and value to set")
 	}
 
-	name = args[0]                            //rename for funsies
+	key = args[0] //rename for funsies
 	value = args[1]
-	err = stub.PutState(name, []byte(value))  //write the variable into the chaincode state
+	err = stub.PutState(key, []byte(value)) //write the variable into the chaincode state
 	if err != nil {
 		return nil, err
 	}
@@ -97,17 +97,17 @@ func (t *SimpleChaincode) write(stub *shim.ChaincodeStub, args []string) ([]byte
 
 // read - query function to read key/value pair
 func (t *SimpleChaincode) read(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
-	var name, jsonResp string
+	var key, jsonResp string
 	var err error
 
 	if len(args) != 1 {
-		return nil, errors.New("Incorrect number of arguments. Expecting name of the var to query")
+		return nil, errors.New("Incorrect number of arguments. Expecting name of the key to query")
 	}
 
-	name = args[0]
-	valAsbytes, err := stub.GetState(name)
+	key = args[0]
+	valAsbytes, err := stub.GetState(key)
 	if err != nil {
-		jsonResp = "{\"Error\":\"Failed to get state for " + name + "\"}"
+		jsonResp = "{\"Error\":\"Failed to get state for " + key + "\"}"
 		return nil, errors.New(jsonResp)
 	}
 


### PR DESCRIPTION
Goal: make the key/value concept explicit. 'name' or 'var' it is not.