### PR TITLE
Corrected references to the main repo which should be to the fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Currently, the Hyperledger Fabric supports chaincode written in Go. We require [
 	cd $GOPATH
 	mkdir -p src/github.com/<yourgithubid>/
 	cd src/github.com/<yourgithubid>/
-	git clone https://github.com/IBM-Blockchain/learn-chaincode.git
+	git clone https://github.com/<yourgithubid>/learn-chaincode.git
 	```
 3. Notice that we have provided two different versions of the chaincode used in this tutorial:  [Start](https://github.com/IBM-Blockchain/learn-chaincode/blob/master/start/chaincode_start.go) - the skeleton chaincode from which you will start developing, and [Finished](https://github.com/IBM-Blockchain/learn-chaincode/blob/master/finished/chaincode_finished.go) - the finished chaincode. 
 4. Make sure it builds in your local environment:
@@ -271,7 +271,7 @@ When you send a deploy request to a peer, you send it the url to your chaincode 
 		"params": {
 			"type": 1,
 			"chaincodeID": {
-				"path": "https://github.com/ibm-blockchain/learn-chaincode/finished"
+				"path": "https://github.com/johndoe/learn-chaincode/finished"
 			},
 			"ctorMsg": {
 				"function": "init",


### PR DESCRIPTION
The instructions that the user is following have instructed them to make a fork, but then the git clone is done from the main repo. This means that they will not be able to commit their changes to the example code back to their fork, and therefore wont be able to complete the exercise of deploying to Bluemix.

Also, later on when configuring the API calls, they are instructed to reference their fork, but the example code again references the main repo. This means they would not actually be running the chaincode they just wrote.