### PR TITLE
Correct git command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following tasks take you through the process of building a pipeline that wil
     # See what files have changed locally.  You should see chaincode_start.go
     git status
     # Stage all changes in the local repository for commit
-    git add -all
+    git add --all
     # Commit all staged changes.  Insert a short description after the -m argument
     git commit -m "Compiled my code"
     # Push local commits back to https://github.com/<YOUR_GITHUB_ID_HERE>/learn-chaincode/


### PR DESCRIPTION
When committing the first build of the tutorial, the README.md tells you to execute `git add -all`.
This command is incorrect and throws the following error:
`error: did you mean `--all` (with two dashes ?)``

This little mistake is solved with just adding the remaining dash like I done.