### PR TITLE
remove redundant \ in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ func (t *SimpleChaincode) write(stub *shim.ChaincodeStub, args []string) ([]byte
     fmt.Println("running write()")
 
     if len(args) != 2 {
-        return nil, errors.New("Incorrect number of arguments. Expecting 2\. name of the key and value to set")
+        return nil, errors.New("Incorrect number of arguments. Expecting 2. name of the key and value to set")
     }
 
     key = args[0]                            //rename for fun


### PR DESCRIPTION
remove redundant \ in readme code snippet that causes problem