### PR TITLE
updating import links for shim package

### DIFF
--- a/finished/chaincode_finished.go
+++ b/finished/chaincode_finished.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
 )
 
 // SimpleChaincode example simple Chaincode implementation

--- a/start/chaincode_start.go
+++ b/start/chaincode_start.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
 )
 
 // SimpleChaincode example simple Chaincode implementation


### PR DESCRIPTION
The shim modules are no longer vendored automatically by Fabric, so they are needed to vendor individually otherwise they lead to the issue as depicted in the attached screenshot.

![chaincode_go_import-error](https://user-images.githubusercontent.com/48702793/131337582-5344aac7-e110-48bb-adb4-0c9f86cc48fc.png)
